### PR TITLE
docs: fix readme translation impact

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 - Pull the Docker image: `docker pull jdneto84/fullcycle` 📥
 - Run the Docker container: `docker run jdneto84/fullcycle` 🏃
-- Print result: "Full Cycle Rocks!!" 🖨️
+- Execution result: `Full Cycle Rocks!!` 🖨️
 
 ### Docker Hub Link:
 


### PR DESCRIPTION
When the translation is executed on the README page, the display of the execution result: "Full Cycle rocks!!" is modified.
A code snippet has been added.